### PR TITLE
Add MyProfile analytics via shared Apps Script backend.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copiá a .env.local para probar analytics en localhost
+VITE_ANALYTICS_URL=https://script.google.com/macros/s/AKfycbz4HnkDRtcoZ8iDJDWNsU3o744kXy3Yb_938E7f3OMQB9e3zQnJ7ZeUvXE8b0owapfhDA/exec
+VITE_ANALYTICS_ALLOW_DEV=true

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,2 @@
+# Misma URL /exec que FORM_SUBMIT_URL de la landing (Apps Script unificado)
+VITE_ANALYTICS_URL=https://script.google.com/macros/s/AKfycbz4HnkDRtcoZ8iDJDWNsU3o744kXy3Yb_938E7f3OMQB9e3zQnJ7ZeUvXE8b0owapfhDA/exec

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules
 dist
 dist-ssr
+.env
+.env.local
 *.local
 .DS_Store
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Al hacer merge a `main`, el workflow `.github/workflows/deploy.yml` publica `dis
 
 En **Settings → Pages**, el origen debe ser **GitHub Actions** (no “Deploy from a branch”).
 
+## Analytics (visitas)
+
+Tracking vía el **mismo** Google Apps Script y Sheet que la landing; eventos del perfil en pestaña **MyProfile**. Setup del script GAS: [`docs/ANALYTICS-GAS.md`](docs/ANALYTICS-GAS.md).
+
+- Producción: URL en `.env.production` (misma `/exec` que la landing).
+- Probar en local: copiá `.env.example` → `.env.local` con `VITE_ANALYTICS_ALLOW_DEV=true`.
+
 ## Estructura
 
 - `src/data/` — contenido del CV (sincronizado con `my-cv.md`)

--- a/docs/ANALYTICS-GAS.md
+++ b/docs/ANALYTICS-GAS.md
@@ -1,0 +1,315 @@
+# Analytics — mismo Sheet y mismo Apps Script que la landing
+
+El perfil usa la **misma URL `/exec`** que *Ingeniero Aumentado*. El front manda `sheet_tab: "MyProfile"` y el script escribe en esa pestaña. La landing sigue yendo a **Eventos** (sin cambios en su JS).
+
+## Pestañas en la Sheet
+
+| Pestaña | Origen |
+|---------|--------|
+| `Aplicaciones` | Formulario landing |
+| `Eventos` | Visitas / funnel landing |
+| `MyProfile` | Visitas del sitio de perfil (GitHub Pages) |
+
+## Script unificado (reemplazar el actual en Apps Script)
+
+Pegá esto en **Extensiones → Apps Script** de la Sheet que ya usás (`SHEET_ID` abajo). Es tu script actual + routing por `sheet_tab`.
+
+```javascript
+/**
+ * Ingeniero Aumentado + MyProfile — formulario, eventos landing y eventos perfil
+ *
+ * 1. Misma Google Sheet (SHEET_ID).
+ * 2. Implementar como app web → copiar URL /exec.
+ * 3. Landing: js/config.js → FORM_SUBMIT_URL
+ * 4. MyProfile: VITE_ANALYTICS_URL (misma URL /exec)
+ */
+
+var SHEET_ID = "1Xom_jpFm3C6B8adqyrWvMiYt_J-R2TC3MpaspHuXqZ8";
+var NOTIFY_EMAIL = "ljappert@agroideassa.com";
+
+var TAB_APPLICATIONS = "Aplicaciones";
+var TAB_EVENTS = "Eventos";
+var TAB_MYPROFILE = "MyProfile";
+
+function doPost(e) {
+  try {
+    var body = parseBody_(e);
+    if (!body || typeof body !== "object") {
+      return jsonResponse_({ ok: false, error: "empty_body" });
+    }
+
+    if (body.type === "event") {
+      return handleEvent_(body);
+    }
+
+    return handleApplication_(body);
+  } catch (err) {
+    return jsonResponse_({ ok: false, error: String(err) });
+  }
+}
+
+function doGet(e) {
+  var p = e && e.parameter ? e.parameter : {};
+  if (p.type === "event" && p.event) {
+    return handleEvent_({
+      type: "event",
+      sheet_tab: p.sheet_tab || "",
+      event: p.event,
+      section: p.section || "",
+      page: p.page || "",
+      page_path: p.page_path || "",
+      session_id: p.session_id || "",
+      utm_source: p.utm_source || "",
+      utm_medium: p.utm_medium || "",
+      utm_campaign: p.utm_campaign || "",
+      utm_content: p.utm_content || "",
+      utm_term: p.utm_term || "",
+    });
+  }
+  return ContentService.createTextOutput(
+    JSON.stringify({ ok: true, service: "ingeniero-aumentado-form", version: 4 })
+  ).setMimeType(ContentService.MimeType.JSON);
+}
+
+function handleApplication_(data) {
+  if (isHoneypot_(data)) {
+    return jsonResponse_({ ok: true, skipped: "honeypot" });
+  }
+
+  var ss = SpreadsheetApp.openById(SHEET_ID);
+  var sheet = getOrCreateSheet_(ss, TAB_APPLICATIONS, APPLICATION_HEADERS_);
+  ensureHeaders_(sheet, APPLICATION_HEADERS_);
+
+  var semaforo = calcSemaforo_(data);
+  var row = [
+    new Date(),
+    semaforo,
+    "",
+    clean_(data.nombre),
+    clean_(data.whatsapp),
+    clean_(data.pais),
+    clean_(data.experiencia),
+    clean_(data.areas || data.tecnologias),
+    clean_(data.ia_codear),
+    clean_(data.costaria),
+    clean_(data.github),
+    clean_(data.email),
+    clean_(data.utm_source),
+    clean_(data.utm_medium),
+    clean_(data.utm_campaign),
+    clean_(data.utm_content),
+    clean_(data.utm_term),
+  ];
+
+  sheet.appendRow(row);
+
+  if (NOTIFY_EMAIL) {
+    try {
+      MailApp.sendEmail({
+        to: NOTIFY_EMAIL,
+        subject: semaforo + " Nueva aplicación — " + clean_(data.nombre),
+        body: formatApplicationEmail_(data, semaforo),
+      });
+    } catch (mailErr) {
+      /* no fallar el POST si el mail falla */
+    }
+  }
+
+  return jsonResponse_({ ok: true, semaforo: semaforo });
+}
+
+function handleEvent_(data) {
+  var tabName = resolveEventTab_(data);
+  var ss = SpreadsheetApp.openById(SHEET_ID);
+  var sheet = getOrCreateSheet_(ss, tabName, EVENT_HEADERS_);
+  ensureHeaders_(sheet, EVENT_HEADERS_);
+
+  sheet.appendRow([
+    new Date(),
+    clean_(data.event),
+    clean_(data.section),
+    clean_(data.page),
+    clean_(data.page_path),
+    clean_(data.session_id),
+    clean_(data.utm_source),
+    clean_(data.utm_medium),
+    clean_(data.utm_campaign),
+    clean_(data.utm_content),
+    clean_(data.utm_term),
+  ]);
+
+  return jsonResponse_({ ok: true, sheet_tab: tabName });
+}
+
+/** MyProfile manda sheet_tab explícito; la landing sigue en Eventos. */
+function resolveEventTab_(data) {
+  var tab = clean_(data.sheet_tab);
+  if (tab === TAB_MYPROFILE) return TAB_MYPROFILE;
+  return TAB_EVENTS;
+}
+
+var APPLICATION_HEADERS_ = [
+  "timestamp",
+  "semaforo",
+  "notas",
+  "nombre",
+  "whatsapp",
+  "pais",
+  "experiencia",
+  "areas",
+  "ia_codear",
+  "costaria",
+  "github",
+  "email",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+];
+
+var EVENT_HEADERS_ = [
+  "timestamp",
+  "event",
+  "section",
+  "page",
+  "page_path",
+  "session_id",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+];
+
+function calcSemaforo_(data) {
+  var exp = clean_(data.experiencia);
+  var areas = clean_(data.areas || data.tecnologias).toLowerCase();
+  var costaria = clean_(data.costaria);
+  var github = clean_(data.github);
+
+  var shortExp = exp === "nada" || exp === "menos-6m";
+  var longExp = exp === "6m-2a" || exp === "2-5a" || exp === "5a-mas";
+  var onlyNinguna =
+    areas.indexOf("ninguna") !== -1 &&
+    areas.indexOf("frontend") === -1 &&
+    areas.indexOf("backend") === -1 &&
+    areas.indexOf("full stack") === -1 &&
+    areas.indexOf("base de datos") === -1 &&
+    areas.indexOf("devops") === -1;
+  var hasSql = areas.indexOf("base de datos") !== -1;
+  var hasGit = github.length > 8;
+  var weakAnswer = costaria.length < 25;
+
+  if (shortExp && onlyNinguna && weakAnswer) {
+    return "🔴";
+  }
+  if (longExp && (hasSql || hasGit) && costaria.length >= 25) {
+    return "🟢";
+  }
+  return "🟡";
+}
+
+function formatApplicationEmail_(data, semaforo) {
+  return [
+    "Semáforo: " + semaforo,
+    "",
+    "Nombre: " + clean_(data.nombre),
+    "WhatsApp: " + clean_(data.whatsapp),
+    "País: " + clean_(data.pais),
+    "Experiencia: " + clean_(data.experiencia),
+    "Áreas: " + clean_(data.areas || data.tecnologias),
+    "IA: " + clean_(data.ia_codear),
+    "",
+    "¿Qué le costaría?:",
+    clean_(data.costaria),
+    "",
+    "GitHub: " + (clean_(data.github) || "(no)"),
+    "Email: " + (clean_(data.email) || "(no)"),
+    "",
+    "UTM: " +
+      [
+        clean_(data.utm_source),
+        clean_(data.utm_medium),
+        clean_(data.utm_campaign),
+        clean_(data.utm_content),
+      ]
+        .filter(Boolean)
+        .join(" / "),
+  ].join("\n");
+}
+
+function parseBody_(e) {
+  if (!e || !e.postData || !e.postData.contents) {
+    return null;
+  }
+  return JSON.parse(e.postData.contents);
+}
+
+function isHoneypot_(data) {
+  return clean_(data.website).length > 0;
+}
+
+function clean_(value) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value).trim();
+}
+
+function getOrCreateSheet_(ss, name, headers) {
+  var sheet = ss.getSheetByName(name);
+  if (!sheet) {
+    sheet = ss.insertSheet(name);
+    sheet.appendRow(headers);
+    sheet.setFrozenRows(1);
+    sheet.getRange(1, 1, 1, headers.length).setFontWeight("bold");
+  }
+  return sheet;
+}
+
+function ensureHeaders_(sheet, headers) {
+  if (sheet.getLastRow() > 0) {
+    return;
+  }
+  sheet.appendRow(headers);
+  sheet.setFrozenRows(1);
+}
+
+function jsonResponse_(obj) {
+  return ContentService.createTextOutput(JSON.stringify(obj)).setMimeType(
+    ContentService.MimeType.JSON
+  );
+}
+```
+
+## Después de pegar el script
+
+1. **Guardar** el proyecto Apps Script.
+2. **Implementar → Administrar implementaciones → editar (lápiz) → Nueva versión → Implementar**  
+   (así la URL `/exec` existente sigue igual; no hace falta cambiar config en la landing).
+3. La pestaña **MyProfile** se crea sola al llegar el primer evento del perfil.
+
+## Configurar MyProfile
+
+La URL de producción va en **`.env.production`** (commiteada; misma `/exec` que `FORM_SUBMIT_URL` de la landing). Vite la incluye en el build de GitHub Pages automáticamente.
+
+Para probar en localhost, copiá `.env.example` → `.env.local`:
+
+```env
+VITE_ANALYTICS_URL=https://script.google.com/macros/s/TU_DEPLOYMENT/exec
+VITE_ANALYTICS_ALLOW_DEV=true
+```
+
+## Eventos del perfil (pestaña MyProfile)
+
+| event | section | Cuándo |
+|-------|---------|--------|
+| `page_view` | `profile` | Carga |
+| `section_view` | id de sección | Scroll (~20% visible) |
+| `contact_email_click` | sección | Click `mailto:` |
+| `email_copy` | `contacto` | Copiar email |
+| `cv_download` | sección | PDF del CV |
+| `outbound_click` | `seccion:dominio` | Links externos |
+
+La landing **no** manda `sheet_tab` → el script usa **Eventos** como siempre. No hace falta tocar `landing-events.js`.

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,9 +13,11 @@ import ScrollToTopButton from '@/components/ScrollToTopButton.vue'
 import { navLinks } from '@/data/nav'
 import { useScrollReveal } from '@/composables/useScrollReveal'
 import { useScrollSpy } from '@/composables/useScrollSpy'
+import { useSiteAnalytics } from '@/composables/useSiteAnalytics'
 
 const activeId = useScrollSpy(navLinks.map((l) => l.id))
 useScrollReveal()
+useSiteAnalytics()
 </script>
 
 <template>

--- a/src/composables/useSiteAnalytics.ts
+++ b/src/composables/useSiteAnalytics.ts
@@ -1,0 +1,116 @@
+import { navLinks } from '@/data/nav'
+import {
+  isAnalyticsEnabled,
+  persistUtmsFromUrl,
+  trackEvent,
+  trackPageView,
+} from '@/utils/analytics'
+import { onMounted, onUnmounted } from 'vue'
+
+function sectionFromElement(el: Element | null): string {
+  const section = el?.closest('section[id]') as HTMLElement | null
+  return section?.id || ''
+}
+
+function linkLabel(anchor: HTMLAnchorElement): string {
+  try {
+    const u = new URL(anchor.href, window.location.href)
+    if (u.protocol === 'mailto:') return u.pathname || 'email'
+    return u.hostname.replace(/^www\./, '')
+  } catch {
+    return anchor.getAttribute('href') || 'link'
+  }
+}
+
+function isCvLink(href: string): boolean {
+  return /\.pdf($|\?)/i.test(href) || /Profile\.pdf/i.test(href)
+}
+
+function bindClickTracking(): void {
+  const onClick = (ev: MouseEvent) => {
+    if (!isAnalyticsEnabled()) return
+
+    const target = ev.target
+    if (!(target instanceof Element)) return
+
+    const copyBtn = target.closest('.contact__copy')
+    if (copyBtn) {
+      trackEvent('email_copy', 'contacto')
+      return
+    }
+
+    const anchor = target.closest('a')
+    if (!anchor?.href) return
+
+    const section = sectionFromElement(anchor)
+    const href = anchor.href
+
+    if (href.startsWith('mailto:')) {
+      trackEvent('contact_email_click', section || 'contacto')
+      return
+    }
+
+    if (isCvLink(href)) {
+      trackEvent('cv_download', section || 'hero')
+      return
+    }
+
+    if (anchor.target === '_blank' && !href.startsWith(window.location.origin)) {
+      trackEvent('outbound_click', `${section || 'site'}:${linkLabel(anchor)}`)
+    }
+  }
+
+  document.addEventListener('click', onClick, true)
+  onUnmounted(() => document.removeEventListener('click', onClick, true))
+}
+
+function bindSectionTracking(): void {
+  const seen = new Set<string>()
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) continue
+        const id = (entry.target as HTMLElement).id
+        if (!id || seen.has(id)) continue
+        seen.add(id)
+        trackEvent('section_view', id)
+      }
+    },
+    { threshold: 0.2, rootMargin: '-10% 0px -55% 0px' },
+  )
+
+  for (const { id } of navLinks) {
+    const el = document.getElementById(id)
+    if (el) observer.observe(el)
+  }
+
+  onUnmounted(() => observer.disconnect())
+}
+
+let booted = false
+
+function boot(): void {
+  if (booted || !isAnalyticsEnabled()) return
+  booted = true
+
+  persistUtmsFromUrl()
+  trackPageView()
+  bindSectionTracking()
+  bindClickTracking()
+}
+
+export function useSiteAnalytics(): void {
+  onMounted(() => {
+    boot()
+
+    const onPageShow = (ev: PageTransitionEvent) => {
+      if (ev.persisted) {
+        booted = false
+        boot()
+      }
+    }
+    window.addEventListener('pageshow', onPageShow)
+    onUnmounted(() => window.removeEventListener('pageshow', onPageShow))
+  })
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,6 +2,8 @@
 
 interface ImportMetaEnv {
   readonly VITE_BUILD_ID?: string
+  readonly VITE_ANALYTICS_URL?: string
+  readonly VITE_ANALYTICS_ALLOW_DEV?: string
 }
 
 interface ImportMeta {

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,225 @@
+/** Visitas y eventos → mismo Apps Script que la landing (pestaña MyProfile). Ver docs/ANALYTICS-GAS.md */
+
+const SESSION_KEY = 'myprofile_session_id'
+const UTM_STORAGE_KEY = 'myprofile_utms'
+/** Pestaña destino en la Google Sheet compartida con la landing */
+const ANALYTICS_SHEET_TAB = 'MyProfile'
+
+const UTM_KEYS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_content',
+  'utm_term',
+] as const
+
+type UtmKey = (typeof UTM_KEYS)[number]
+type Utms = Partial<Record<UtmKey, string>>
+
+export type AnalyticsEventPayload = {
+  type: 'event'
+  /** Pestaña en la Sheet; el script de la landing usa "Eventos" por defecto */
+  sheet_tab: string
+  event: string
+  section: string
+  page: string
+  page_path: string
+  session_id: string
+  utm_source: string
+  utm_medium: string
+  utm_campaign: string
+  utm_content: string
+  utm_term: string
+}
+
+export type TrackOptions = {
+  /** visit = beacon + POST (+ GET fuera de in-app browsers) */
+  mode?: 'visit' | 'post' | 'get'
+  /** Si false, permite el mismo evento+section en la misma carga */
+  dedupe?: boolean
+}
+
+const sent = new Set<string>()
+
+function endpoint(): string {
+  const url = (import.meta.env.VITE_ANALYTICS_URL ?? '').trim()
+  if (!url || url.includes('REEMPLAZAR')) return ''
+  return url
+}
+
+export function isAnalyticsDevOrigin(): boolean {
+  if (import.meta.env.VITE_ANALYTICS_ALLOW_DEV === 'true') return false
+  if (typeof window === 'undefined') return true
+
+  if (window.location.protocol === 'file:') return true
+
+  const h = (window.location.hostname || '').toLowerCase()
+  return h === 'localhost' || h === '127.0.0.1' || h === '[::1]' || h.endsWith('.local')
+}
+
+export function isAnalyticsEnabled(): boolean {
+  return Boolean(endpoint()) && !isAnalyticsDevOrigin()
+}
+
+function readUtmsFromParams(params: URLSearchParams): Utms {
+  const out: Utms = {}
+  for (const key of UTM_KEYS) {
+    const v = params.get(key)
+    if (v) out[key] = v
+  }
+  return out
+}
+
+export function persistUtmsFromUrl(): void {
+  const fromUrl = readUtmsFromParams(new URLSearchParams(window.location.search))
+  if (!Object.keys(fromUrl).length) return
+  try {
+    localStorage.setItem(UTM_STORAGE_KEY, JSON.stringify(fromUrl))
+  } catch {
+    /* privado / ITP */
+  }
+}
+
+function readStoredUtms(): Utms {
+  try {
+    const raw = localStorage.getItem(UTM_STORAGE_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as unknown
+    return parsed && typeof parsed === 'object' ? (parsed as Utms) : {}
+  } catch {
+    return {}
+  }
+}
+
+function readUtms(): Record<UtmKey, string> {
+  const fromUrl = readUtmsFromParams(new URLSearchParams(window.location.search))
+  const stored = readStoredUtms()
+  const out = {} as Record<UtmKey, string>
+  for (const key of UTM_KEYS) {
+    out[key] = fromUrl[key] || stored[key] || ''
+  }
+  return out
+}
+
+function sessionId(): string {
+  try {
+    const existing = sessionStorage.getItem(SESSION_KEY)
+    if (existing) return existing
+    const id = `s_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
+    sessionStorage.setItem(SESSION_KEY, id)
+    return id
+  } catch {
+    return 's_anon'
+  }
+}
+
+function pageLabel(): string {
+  const host = window.location.host || window.location.hostname || ''
+  return host ? `${host} · profile` : 'profile'
+}
+
+function buildPayload(event: string, section: string): AnalyticsEventPayload {
+  const utms = readUtms()
+  return {
+    type: 'event',
+    sheet_tab: ANALYTICS_SHEET_TAB,
+    event,
+    section: section || '',
+    page: pageLabel(),
+    page_path: window.location.pathname + window.location.search,
+    session_id: sessionId(),
+    utm_source: utms.utm_source,
+    utm_medium: utms.utm_medium,
+    utm_campaign: utms.utm_campaign,
+    utm_content: utms.utm_content,
+    utm_term: utms.utm_term,
+  }
+}
+
+function isInAppBrowser(): boolean {
+  const ua = navigator.userAgent || ''
+  return /Instagram|FBAN|FBAV|FB_IAB|FBIOS|MetaIAB/i.test(ua)
+}
+
+function sendBeacon(payload: AnalyticsEventPayload): boolean {
+  const url = endpoint()
+  if (!url || !navigator.sendBeacon) return false
+  try {
+    const blob = new Blob([JSON.stringify(payload)], {
+      type: 'text/plain;charset=utf-8',
+    })
+    return navigator.sendBeacon(url, blob)
+  } catch {
+    return false
+  }
+}
+
+function sendPost(payload: AnalyticsEventPayload): void {
+  const url = endpoint()
+  if (!url) return
+
+  fetch(url, {
+    method: 'POST',
+    mode: 'no-cors',
+    headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+    body: JSON.stringify(payload),
+    keepalive: true,
+  }).catch(() => {
+    /* silencioso */
+  })
+}
+
+function sendGet(payload: AnalyticsEventPayload): void {
+  const url = endpoint()
+  if (!url) return
+
+  const base = url.includes('?') ? url.split('?')[0]! : url
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(payload)) {
+    if (value !== undefined && value !== null) {
+      params.set(key, String(value))
+    }
+  }
+
+  const img = new Image()
+  img.src = `${base}?${params.toString()}`
+}
+
+function deliver(payload: AnalyticsEventPayload, mode: TrackOptions['mode']): void {
+  if (mode === 'visit') {
+    const beaconOk = sendBeacon(payload)
+    if (!beaconOk) sendPost(payload)
+    if (!isInAppBrowser()) {
+      sendGet(payload)
+    } else if (!beaconOk) {
+      window.setTimeout(() => sendPost(payload), 2500)
+    }
+    return
+  }
+
+  if (mode === 'get') {
+    sendGet(payload)
+    return
+  }
+
+  if (!sendBeacon(payload)) sendPost(payload)
+}
+
+/** Registra un evento en la Sheet (si hay URL configurada y no es dev). */
+export function trackEvent(
+  event: string,
+  section = '',
+  options: TrackOptions = {},
+): void {
+  if (!isAnalyticsEnabled()) return
+
+  const dedupeKey = `${event}|${section}`
+  if (options.dedupe !== false && sent.has(dedupeKey)) return
+  if (options.dedupe !== false) sent.add(dedupeKey)
+
+  deliver(buildPayload(event, section), options.mode ?? 'post')
+}
+
+export function trackPageView(): void {
+  trackEvent('page_view', 'profile', { mode: 'visit' })
+}


### PR DESCRIPTION
Track page views, section scroll, and contact/CV clicks into the MyProfile sheet tab using the same GAS deployment as the landing.