### PR TITLE
Add device and browser context to MyProfile analytics events.

### DIFF
--- a/docs/ANALYTICS-GAS.md
+++ b/docs/ANALYTICS-GAS.md
@@ -64,6 +64,15 @@ function doGet(e) {
       utm_campaign: p.utm_campaign || "",
       utm_content: p.utm_content || "",
       utm_term: p.utm_term || "",
+      device_type: p.device_type || "",
+      browser: p.browser || "",
+      os: p.os || "",
+      viewport: p.viewport || "",
+      screen: p.screen || "",
+      language: p.language || "",
+      referrer: p.referrer || "",
+      timezone: p.timezone || "",
+      user_agent: p.user_agent || "",
     });
   }
   return ContentService.createTextOutput(
@@ -120,11 +129,20 @@ function handleApplication_(data) {
 
 function handleEvent_(data) {
   var tabName = resolveEventTab_(data);
+  var headers = tabName === TAB_MYPROFILE ? MYPROFILE_HEADERS_ : EVENT_HEADERS_;
   var ss = SpreadsheetApp.openById(SHEET_ID);
-  var sheet = getOrCreateSheet_(ss, tabName, EVENT_HEADERS_);
-  ensureHeaders_(sheet, EVENT_HEADERS_);
+  var sheet = getOrCreateSheet_(ss, tabName, headers);
+  ensureHeaders_(sheet, headers);
 
-  sheet.appendRow([
+  var row =
+    tabName === TAB_MYPROFILE ? buildMyProfileRow_(data) : buildEventRow_(data);
+  sheet.appendRow(row);
+
+  return jsonResponse_({ ok: true, sheet_tab: tabName });
+}
+
+function buildEventRow_(data) {
+  return [
     new Date(),
     clean_(data.event),
     clean_(data.section),
@@ -136,9 +154,21 @@ function handleEvent_(data) {
     clean_(data.utm_campaign),
     clean_(data.utm_content),
     clean_(data.utm_term),
-  ]);
+  ];
+}
 
-  return jsonResponse_({ ok: true, sheet_tab: tabName });
+function buildMyProfileRow_(data) {
+  return buildEventRow_(data).concat([
+    clean_(data.device_type),
+    clean_(data.browser),
+    clean_(data.os),
+    clean_(data.viewport),
+    clean_(data.screen),
+    clean_(data.language),
+    clean_(data.referrer),
+    clean_(data.timezone),
+    clean_(data.user_agent),
+  ]);
 }
 
 /** MyProfile manda sheet_tab explícito; la landing sigue en Eventos. */
@@ -181,6 +211,18 @@ var EVENT_HEADERS_ = [
   "utm_content",
   "utm_term",
 ];
+
+var MYPROFILE_HEADERS_ = EVENT_HEADERS_.concat([
+  "device_type",
+  "browser",
+  "os",
+  "viewport",
+  "screen",
+  "language",
+  "referrer",
+  "timezone",
+  "user_agent",
+]);
 
 function calcSemaforo_(data) {
   var exp = clean_(data.experiencia);
@@ -269,10 +311,19 @@ function getOrCreateSheet_(ss, name, headers) {
 }
 
 function ensureHeaders_(sheet, headers) {
-  if (sheet.getLastRow() > 0) {
+  if (sheet.getLastRow() === 0) {
+    sheet.appendRow(headers);
+    sheet.setFrozenRows(1);
     return;
   }
-  sheet.appendRow(headers);
+  var lastCol = sheet.getLastColumn();
+  if (lastCol >= headers.length) {
+    return;
+  }
+  sheet.getRange(1, lastCol + 1, 1, headers.length).setValues([
+    headers.slice(lastCol),
+  ]);
+  sheet.getRange(1, 1, 1, headers.length).setFontWeight("bold");
   sheet.setFrozenRows(1);
 }
 
@@ -313,3 +364,21 @@ VITE_ANALYTICS_ALLOW_DEV=true
 | `outbound_click` | `seccion:dominio` | Links externos |
 
 La landing **no** manda `sheet_tab` → el script usa **Eventos** como siempre. No hace falta tocar `landing-events.js`.
+
+## Columnas extra en MyProfile
+
+| Columna | Ejemplo | Origen |
+|---------|---------|--------|
+| `device_type` | `mobile`, `tablet`, `desktop` | User-Agent |
+| `browser` | `Chrome`, `Firefox`, `Safari` | User-Agent |
+| `os` | `Windows`, `macOS`, `Android` | User-Agent |
+| `viewport` | `390x844` | Tamaño ventana |
+| `screen` | `1920x1080` | Pantalla física |
+| `language` | `es-AR` | `navigator.language` |
+| `referrer` | URL de origen | `document.referrer` |
+| `timezone` | `America/Argentina/Buenos_Aires` | `Intl` |
+| `user_agent` | string completo (truncado) | Navegador |
+
+Si la pestaña **MyProfile** ya existía, al publicar una **nueva versión** del script se agregan solas las columnas faltantes en la fila 1.
+
+**IP:** Apps Script en modo app web **no expone la IP del visitante** en `doPost`/`doGet`. Para IP haría falta otro backend o un servicio externo; por privacidad y simplicidad no la incluimos.

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,5 +1,7 @@
 /** Visitas y eventos → mismo Apps Script que la landing (pestaña MyProfile). Ver docs/ANALYTICS-GAS.md */
 
+import { getClientContext, getClientContextForGet } from '@/utils/clientContext'
+
 const SESSION_KEY = 'myprofile_session_id'
 const UTM_STORAGE_KEY = 'myprofile_utms'
 /** Pestaña destino en la Google Sheet compartida con la landing */
@@ -30,6 +32,15 @@ export type AnalyticsEventPayload = {
   utm_campaign: string
   utm_content: string
   utm_term: string
+  device_type: string
+  browser: string
+  os: string
+  viewport: string
+  screen: string
+  language: string
+  referrer: string
+  timezone: string
+  user_agent: string
 }
 
 export type TrackOptions = {
@@ -120,6 +131,7 @@ function pageLabel(): string {
 
 function buildPayload(event: string, section: string): AnalyticsEventPayload {
   const utms = readUtms()
+  const ctx = getClientContext()
   return {
     type: 'event',
     sheet_tab: ANALYTICS_SHEET_TAB,
@@ -133,7 +145,18 @@ function buildPayload(event: string, section: string): AnalyticsEventPayload {
     utm_campaign: utms.utm_campaign,
     utm_content: utms.utm_content,
     utm_term: utms.utm_term,
+    ...ctx,
   }
+}
+
+function payloadForGet(payload: AnalyticsEventPayload): Record<string, string> {
+  const compact = getClientContextForGet()
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries({ ...payload, ...compact })) {
+    if (key === 'user_agent') continue
+    if (value !== undefined && value !== null) out[key] = String(value)
+  }
+  return out
 }
 
 function isInAppBrowser(): boolean {
@@ -174,12 +197,7 @@ function sendGet(payload: AnalyticsEventPayload): void {
   if (!url) return
 
   const base = url.includes('?') ? url.split('?')[0]! : url
-  const params = new URLSearchParams()
-  for (const [key, value] of Object.entries(payload)) {
-    if (value !== undefined && value !== null) {
-      params.set(key, String(value))
-    }
-  }
+  const params = new URLSearchParams(payloadForGet(payload))
 
   const img = new Image()
   img.src = `${base}?${params.toString()}`

--- a/src/utils/clientContext.ts
+++ b/src/utils/clientContext.ts
@@ -1,0 +1,90 @@
+export type ClientContext = {
+  device_type: string
+  browser: string
+  os: string
+  viewport: string
+  screen: string
+  language: string
+  referrer: string
+  timezone: string
+  user_agent: string
+}
+
+let cached: ClientContext | null = null
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value
+  return value.slice(0, max)
+}
+
+function detectDeviceType(ua: string): string {
+  if (/iPad|Tablet|PlayBook|Silk|(Android(?!.*Mobile))/i.test(ua)) return 'tablet'
+  if (/Mobile|iPhone|iPod|Android.*Mobile|IEMobile|Opera Mini/i.test(ua)) return 'mobile'
+  return 'desktop'
+}
+
+function detectBrowser(ua: string): string {
+  if (/Edg\//i.test(ua)) return 'Edge'
+  if (/OPR\/|Opera/i.test(ua)) return 'Opera'
+  if (/Firefox\//i.test(ua)) return 'Firefox'
+  if (/Chrome\//i.test(ua) && !/Edg\//i.test(ua)) return 'Chrome'
+  if (/Safari\//i.test(ua) && !/Chrome\//i.test(ua)) return 'Safari'
+  return 'Other'
+}
+
+function detectOs(ua: string, platform: string): string {
+  if (/Windows/i.test(ua)) return 'Windows'
+  if (/Mac OS X|Macintosh/i.test(ua)) return 'macOS'
+  if (/iPhone|iPad|iPod/i.test(ua)) return 'iOS'
+  if (/Android/i.test(ua)) return 'Android'
+  if (/CrOS/i.test(ua)) return 'ChromeOS'
+  if (/Linux/i.test(ua) || /Linux/i.test(platform)) return 'Linux'
+  return 'Other'
+}
+
+function readTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || ''
+  } catch {
+    return ''
+  }
+}
+
+/** Metadatos del visitante (cacheados por carga). */
+export function getClientContext(): ClientContext {
+  if (cached) return cached
+
+  const ua = navigator.userAgent || ''
+  const platform = navigator.platform || ''
+
+  cached = {
+    device_type: detectDeviceType(ua),
+    browser: detectBrowser(ua),
+    os: detectOs(ua, platform),
+    viewport: `${window.innerWidth}x${window.innerHeight}`,
+    screen: `${screen.width}x${screen.height}`,
+    language: navigator.language || '',
+    referrer: truncate(document.referrer || '', 500),
+    timezone: readTimezone(),
+    user_agent: truncate(ua, 500),
+  }
+
+  return cached
+}
+
+/** Versión compacta para GET (evita URLs demasiado largas). */
+export function getClientContextForGet(): Omit<ClientContext, 'user_agent'> & {
+  user_agent?: never
+} {
+  const ctx = getClientContext()
+  return {
+    device_type: ctx.device_type,
+    browser: ctx.browser,
+    os: ctx.os,
+    viewport: ctx.viewport,
+    screen: ctx.screen,
+    language: ctx.language,
+    referrer: truncate(ctx.referrer, 200),
+    timezone: ctx.timezone,
+  }
+}


### PR DESCRIPTION
Capture visitor metadata in the front end and extend the GAS MyProfile sheet columns while keeping the landing Eventos tab unchanged.